### PR TITLE
Simple fix

### DIFF
--- a/src/xpinyin/__init__.py
+++ b/src/xpinyin/__init__.py
@@ -91,8 +91,6 @@ class Pinyin(object):
                                 if vowels in t:
                                     t = t.replace(vowels[-1], PinyinToneMark[tone][num])
                                     break
-                                else:
-                                    t += "!"
                 r += t
                 t = ""
         r += t

--- a/src/xpinyin/tests.py
+++ b/src/xpinyin/tests.py
@@ -1,6 +1,6 @@
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import unittest
-
 
 class PinyinTests(unittest.TestCase):
     def Pinyin(self, *a, **kw):
@@ -24,6 +24,9 @@ class PinyinTests(unittest.TestCase):
     def test_get_pinyin_with_tone_marks(self):
         self.assertEqual(self.p.get_pinyin(u'上海', show_tone_marks=True), u'sh\xe0ng-h\u01cei')
 
+    def test_get_pinyin_with_tone_marks(self):
+        self.assertEqual(self.p.get_pinyin(u'秋', show_tone_marks=True), u'qiū')
+
     def test_get_initial(self):
         self.assertEqual(self.p.get_initial(u'你'), u'N')
 
@@ -33,3 +36,6 @@ class PinyinTests(unittest.TestCase):
     def test_get_initials_with_splitter(self):
         self.assertEqual(self.p.get_initials(u'你好', u' '), u'N H')
         self.assertEqual(self.p.get_initials(u'你好', u''), u'NH')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #29 

Removed extraneous "!" being appended to non-'a' vowel replacements when show_tone_marks=True; also added simple unitest.main() for non-nose users